### PR TITLE
Fix Tempo exporter port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     container_name: tempo
     ports:
       - "4317:4317"         # OTLP gRPC
+      - "4318:4318"         # OTLP HTTP
       - "3200:3200"         # Tempo UI
     environment:
       - TEMPO_OTLP_GRPC_BIND_ADDRESS=0.0.0.0:4317

--- a/src/app/tracking.service.ts
+++ b/src/app/tracking.service.ts
@@ -60,7 +60,10 @@ import { resourceFromAttributes } from '@opentelemetry/resources';
 export class TracingService {
   static initTracing(): void {
     const exporter = new OTLPTraceExporter({
-      url: 'http://localhost:8080/v1/traces', 
+      // Tempo exposes the OTLP HTTP receiver on port 4318 by default. The
+      // exporter was mistakenly configured to use port 8080, which does not
+      // accept trace data. Update the endpoint so traces are sent to Tempo.
+      url: 'http://localhost:4318/v1/traces',
     });
 
      const resource = resourceFromAttributes({


### PR DESCRIPTION
## Summary
- fix OTLP exporter endpoint for Tempo
- expose Tempo HTTP port in compose file

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b955e0670832cb78c54c451c72b52